### PR TITLE
Add Jest tests and CI update

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -22,7 +22,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Build
+    - name: Build and Test
       run: |
         npm install
         gulp
+        npm test

--- a/netlify/functions/ask-ai.js
+++ b/netlify/functions/ask-ai.js
@@ -40,7 +40,7 @@ export const handler = async (event) => {
 
         return {
             statusCode: 200,
-            body: JSON.stringify({ text: text }),
+            body: JSON.stringify({ response: text }),
             headers: { 'Content-Type': 'application/json' },
         };
         

--- a/netlify/functions/ask-ai.test.js
+++ b/netlify/functions/ask-ai.test.js
@@ -1,0 +1,40 @@
+import { jest } from '@jest/globals';
+
+// Mock the @google/genai module to avoid network calls
+jest.unstable_mockModule('@google/genai', () => ({
+  GoogleGenAI: jest.fn().mockImplementation(() => ({
+    models: {
+      generateContent: jest.fn().mockResolvedValue({ text: 'mock reply' })
+    }
+  }))
+}));
+
+const { handler } = await import('./ask-ai.js');
+
+const mockEvent = (method, body) => ({
+  httpMethod: method,
+  body: body ? JSON.stringify(body) : undefined
+});
+
+describe('ask-ai Netlify function', () => {
+  test('returns 405 for GET requests', async () => {
+    const result = await handler(mockEvent('GET'));
+    expect(result.statusCode).toBe(405);
+  });
+
+  test('returns 400 when question or context missing', async () => {
+    process.env.API_KEY = 'x';
+    let result = await handler(mockEvent('POST', { question: 'hi' }));
+    expect(result.statusCode).toBe(400);
+    result = await handler(mockEvent('POST', { context: 'ctx' }));
+    expect(result.statusCode).toBe(400);
+  });
+
+  test('returns 200 and response on valid POST', async () => {
+    process.env.API_KEY = 'x';
+    const result = await handler(mockEvent('POST', { question: 'hi', context: 'ctx' }));
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.response).toBeDefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,5 +4,11 @@
   "description": "Temario para Examen Final de Medicina Interna",
   "dependencies": {
     "@google/genai": "^1.8.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }


### PR DESCRIPTION
## Summary
- add jest for testing
- test Netlify `ask-ai` function
- return `response` prop from handler
- run `npm test` in CI workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688444281724832cac468d976640b245