### PR TITLE
Fix ask-ai return object key

### DIFF
--- a/netlify/functions/ask-ai.js
+++ b/netlify/functions/ask-ai.js
@@ -40,7 +40,7 @@ export const handler = async (event) => {
 
         return {
             statusCode: 200,
-            body: JSON.stringify({ text: text }),
+            body: JSON.stringify({ response: text }),
             headers: { 'Content-Type': 'application/json' },
         };
         


### PR DESCRIPTION
## Summary
- standardize ask-ai JSON response to use `{ response: text }`

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688538b855cc832c85b4a523e1a4d151